### PR TITLE
Implement FastAPI-based vLLM key management portal

### DIFF
--- a/app/audit.py
+++ b/app/audit.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+from .config import Settings
+
+logger = logging.getLogger(__name__)
+
+
+def append_audit_event(
+    settings: Settings,
+    *,
+    actor: str,
+    action: str,
+    subject: str,
+    ip: Optional[str] = None,
+) -> None:
+    record = {
+        "ts": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "actor": actor,
+        "action": action,
+        "subject": subject,
+        "ip": ip,
+    }
+    path: Path = settings.audit_log_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+    except Exception:  # noqa: BLE001
+        logger.exception("Failed to append audit log entry")

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Optional
+
+from fastapi import Depends, HTTPException, Request, Response, status
+from itsdangerous import BadSignature, URLSafeTimedSerializer
+
+from .config import Settings, get_settings
+from .ldap_client import LDAPClient
+from .models import AuthenticatedUser, LoginRequest
+
+logger = logging.getLogger(__name__)
+
+SESSION_COOKIE_NAME = "vllm_session"
+SESSION_MAX_AGE_SECONDS = 60 * 60 * 24
+
+
+class SessionManager:
+    def __init__(self, settings: Settings):
+        self.serializer = URLSafeTimedSerializer(settings.session_secret, salt="vllm-keyportal")
+
+    def create(self, response: Response, user: AuthenticatedUser) -> None:
+        payload = {
+            "username": user.username,
+            "email": user.email,
+            "display_name": user.display_name,
+            "is_admin": user.is_admin,
+            "iat": datetime.now(timezone.utc).timestamp(),
+        }
+        token = self.serializer.dumps(payload)
+        response.set_cookie(
+            SESSION_COOKIE_NAME,
+            token,
+            max_age=SESSION_MAX_AGE_SECONDS,
+            secure=True,
+            httponly=True,
+            samesite="strict",
+        )
+
+    def clear(self, response: Response) -> None:
+        response.delete_cookie(SESSION_COOKIE_NAME)
+
+    def load(self, request: Request) -> Optional[AuthenticatedUser]:
+        token = request.cookies.get(SESSION_COOKIE_NAME)
+        if not token:
+            return None
+        try:
+            data = self.serializer.loads(token, max_age=SESSION_MAX_AGE_SECONDS)
+            return AuthenticatedUser(**{k: data.get(k) for k in ("username", "email", "display_name", "is_admin")})
+        except BadSignature:
+            logger.warning("Invalid session token")
+            return None
+
+
+def get_session_manager(settings: Settings = Depends(get_settings)) -> SessionManager:
+    return SessionManager(settings)
+
+
+def get_ldap_client(settings: Settings = Depends(get_settings)) -> LDAPClient:
+    return LDAPClient(settings)
+
+
+def get_current_user(
+    request: Request,
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> AuthenticatedUser:
+    user = session_manager.load(request)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    return user
+
+
+def require_admin(user: AuthenticatedUser = Depends(get_current_user)) -> AuthenticatedUser:
+    if not user.is_admin:
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin privileges required")
+    return user
+
+
+def authenticate_and_create_session(
+    payload: LoginRequest,
+    request: Request,
+    response: Response,
+    ldap_client: LDAPClient = Depends(get_ldap_client),
+    session_manager: SessionManager = Depends(get_session_manager),
+) -> AuthenticatedUser:
+    info = ldap_client.authenticate(payload.username, payload.password)
+    if not info:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+    is_admin = ldap_client.is_admin(info)
+    user = AuthenticatedUser(
+        username=info.username,
+        email=info.email,
+        display_name=info.display_name,
+        is_admin=is_admin,
+    )
+    session_manager.create(response, user)
+    request.state.user = user
+    return user

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import List, Optional
+
+from pydantic import BaseSettings, Field, validator
+
+
+class Settings(BaseSettings):
+    ldap_uri: str = Field(..., env="LDAP_URI")
+    ldap_bind_dn: str = Field(..., env="LDAP_BIND_DN")
+    ldap_bind_password: str = Field(..., env="LDAP_BIND_PASSWORD")
+    ldap_base_dn: str = Field(..., env="LDAP_BASE_DN")
+    ldap_mail_attr: str = Field("mail", env="LDAP_MAIL_ATTR")
+    ldap_display_attr: str = Field("displayName", env="LDAP_DISPLAY_ATTR")
+    admin_users: List[str] = Field(default_factory=list, env="ADMIN_USERS")
+    admin_group_dn: Optional[str] = Field(default=None, env="ADMIN_GROUP_DN")
+    keys_json_path: Path = Field(Path("/etc/vllm/keys.json"), env="KEYS_JSON_PATH")
+    key_default_ttl_days: int = Field(30, env="KEY_DEFAULT_TTL_DAYS")
+    session_secret: str = Field(..., env="SESSION_SECRET")
+    https_only: bool = Field(True, env="HTTPS_ONLY")
+    audit_log_path: Path = Field(Path("/var/log/vllm-keyportal/audit.log"), env="AUDIT_LOG_PATH")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+        case_sensitive = False
+
+    @validator("admin_users", pre=True)
+    def _split_admin_users(cls, value: str | List[str]) -> List[str]:
+        if isinstance(value, list):
+            return [v.strip() for v in value if v.strip()]
+        if not value:
+            return []
+        return [part.strip() for part in value.split(",") if part.strip()]
+
+    @validator("key_default_ttl_days")
+    def _validate_ttl(cls, value: int) -> int:
+        if value <= 0:
+            raise ValueError("KEY_DEFAULT_TTL_DAYS must be positive")
+        return value
+
+    @validator("admin_group_dn")
+    def _empty_string_to_none(cls, value: Optional[str]) -> Optional[str]:
+        if value and value.strip():
+            return value.strip()
+        return None
+
+    @validator("keys_json_path", "audit_log_path")
+    def _expand_paths(cls, value: Path) -> Path:
+        return Path(os.path.expanduser(str(value)))
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/app/keys_store.py
+++ b/app/keys_store.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+import os
+import secrets
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, Tuple
+
+import fcntl
+
+from .audit import append_audit_event
+from .config import Settings
+from .models import KeyEntry, KeysDocument
+
+TOKEN_LENGTH_BYTES = 48
+
+
+class KeyStoreError(Exception):
+    """Raised when the JSON document cannot be processed."""
+
+
+class KeyStore:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+        self.path: Path = settings.keys_json_path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if not self.path.exists():
+            self._write_document(KeysDocument())
+
+    def generate_token(self) -> str:
+        return secrets.token_urlsafe(TOKEN_LENGTH_BYTES)
+
+    def get_personal_key(self, identifier: str) -> Tuple[str, KeyEntry] | None:
+        subject = self._personal_subject(identifier)
+        doc = self._read_document()
+        entry = doc.gpt.get(subject)
+        if entry:
+            return subject, entry
+        return None
+
+    def upsert_personal_key(self, *, identifier: str, ttl_days: int, actor: str, ip: str | None) -> KeyEntry:
+        now = datetime.now(timezone.utc)
+        expires = now + timedelta(days=ttl_days)
+        entry = KeyEntry(key=self.generate_token(), created_at=now, expires_at=expires)
+        subject = self._personal_subject(identifier)
+
+        def modifier(data: Dict[str, KeyEntry]) -> str:
+            action = "create" if subject not in data else "rotate"
+            data[subject] = entry
+            return action
+
+        action = self._update_document(
+            modifier=modifier,
+            actor=actor,
+            default_action="create",
+            subject=subject,
+            ip=ip,
+        )
+        if action not in {"create", "rotate"}:
+            raise KeyStoreError("Unexpected action while upserting personal key")
+        return entry
+
+    def delete_personal_key(self, *, identifier: str, actor: str, ip: str | None) -> None:
+        subject = self._personal_subject(identifier)
+
+        def modifier(data: Dict[str, KeyEntry]) -> str:
+            if subject in data:
+                data.pop(subject, None)
+                return "delete"
+            return "noop"
+
+        self._update_document(
+            modifier=modifier,
+            actor=actor,
+            default_action="noop",
+            subject=subject,
+            ip=ip,
+        )
+
+    def set_app_key(self, *, name: str, key: str | None, actor: str, ip: str | None) -> KeyEntry:
+        now = datetime.now(timezone.utc)
+        entry = KeyEntry(key=key or self.generate_token(), created_at=now, expires_at=None)
+        subject = self._app_subject(name)
+
+        def modifier(data: Dict[str, KeyEntry]) -> str:
+            action = "create" if subject not in data else "rotate"
+            data[subject] = entry
+            return action
+
+        action = self._update_document(
+            modifier=modifier,
+            actor=actor,
+            default_action="create",
+            subject=subject,
+            ip=ip,
+        )
+        if action not in {"create", "rotate"}:
+            raise KeyStoreError("Unexpected action while setting app key")
+        return entry
+
+    def delete_app_key(self, *, name: str, actor: str, ip: str | None) -> None:
+        subject = self._app_subject(name)
+
+        def modifier(data: Dict[str, KeyEntry]) -> str:
+            if subject in data:
+                data.pop(subject, None)
+                return "delete"
+            return "noop"
+
+        self._update_document(
+            modifier=modifier,
+            actor=actor,
+            default_action="noop",
+            subject=subject,
+            ip=ip,
+        )
+
+    def list_entries(self) -> Iterable[Tuple[str, KeyEntry]]:
+        return tuple(self._read_document().gpt.items())
+
+    def has_subject(self, subject: str) -> bool:
+        doc = self._read_document()
+        return subject in doc.gpt
+
+    def has_app_key(self, name: str) -> bool:
+        return self.has_subject(self._app_subject(name))
+
+    def expire_stale_keys(self) -> int:
+        now = datetime.now(timezone.utc)
+        removed: Dict[str, KeyEntry] = {}
+
+        def modifier(data: Dict[str, KeyEntry]) -> str:
+            for subject, entry in list(data.items()):
+                if subject.startswith("user:") and entry.expires_at and entry.expires_at <= now:
+                    removed[subject] = data.pop(subject)
+            return "expire" if removed else "noop"
+
+        action = self._update_document(
+            modifier=modifier,
+            actor="system",
+            default_action="noop",
+            subject="user:*",
+            ip=None,
+            audit_each_removed=removed,
+        )
+        if action not in {"expire", "noop"}:
+            raise KeyStoreError("Unexpected action during expiration")
+        return len(removed)
+
+    def _personal_subject(self, identifier: str) -> str:
+        return f"user:{identifier.lower()}"
+
+    def _app_subject(self, name: str) -> str:
+        return f"app:{name.lower()}"
+
+    def _read_document(self) -> KeysDocument:
+        with self._locked_file(shared=True) as file:
+            file.seek(0)
+            content = file.read().strip()
+            if not content:
+                return KeysDocument()
+            data = json.loads(content)
+            return KeysDocument(**data)
+
+    def _write_document(self, document: KeysDocument) -> None:
+        tmp_path = self.path.with_suffix(".tmp")
+        json_data = document.json(indent=2, sort_keys=True)
+        with tmp_path.open("w", encoding="utf-8") as handle:
+            handle.write(json_data)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, self.path)
+        os.chmod(self.path, 0o640)
+
+    def _update_document(
+        self,
+        *,
+        modifier,
+        actor: str,
+        default_action: str,
+        subject: str,
+        ip: str | None,
+        audit_each_removed: Dict[str, KeyEntry] | None = None,
+    ) -> str:
+        with self._locked_file(shared=False) as file:
+            file.seek(0)
+            content = file.read().strip()
+            document = KeysDocument(**json.loads(content)) if content else KeysDocument()
+            original_data = dict(document.gpt)
+            data = dict(document.gpt)
+            try:
+                action = modifier(data) or default_action
+            except Exception as exc:  # noqa: BLE001
+                raise KeyStoreError("Failed to modify keys document") from exc
+            if data != original_data:
+                document = KeysDocument(gpt=data)
+                self._write_document(document)
+            else:
+                action = "noop"
+        if audit_each_removed:
+            for removed_subject in audit_each_removed:
+                append_audit_event(self.settings, actor=actor, action="expire", subject=removed_subject, ip=ip)
+        elif action != "noop":
+            append_audit_event(self.settings, actor=actor, action=action, subject=subject, ip=ip)
+        return action
+
+    @contextmanager
+    def _locked_file(self, *, shared: bool) -> Iterator[object]:
+        with self.path.open("a+", encoding="utf-8") as file:
+            file.seek(0)
+            lock_type = fcntl.LOCK_SH if shared else fcntl.LOCK_EX
+            fcntl.flock(file.fileno(), lock_type)
+            try:
+                yield file
+            finally:
+                fcntl.flock(file.fileno(), fcntl.LOCK_UN)

--- a/app/ldap_client.py
+++ b/app/ldap_client.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from typing import Optional
+
+from ldap3 import ALL, Connection, NTLM, Server, SUBTREE
+
+from .config import Settings
+from .models import UserInfo
+
+logger = logging.getLogger(__name__)
+
+
+def _build_server(settings: Settings) -> Server:
+    return Server(settings.ldap_uri, get_info=ALL)
+
+
+@contextmanager
+def _service_connection(settings: Settings):
+    server = _build_server(settings)
+    conn = Connection(
+        server,
+        user=settings.ldap_bind_dn,
+        password=settings.ldap_bind_password,
+        auto_bind=True,
+    )
+    try:
+        yield conn
+    finally:
+        conn.unbind()
+
+
+class LDAPClient:
+    def __init__(self, settings: Settings):
+        self.settings = settings
+
+    def authenticate(self, username: str, password: str) -> Optional[UserInfo]:
+        username = username.strip()
+        if not username or not password:
+            return None
+        server = _build_server(self.settings)
+        user_dn = f"{username}@{self._domain_from_bind()}"
+        try:
+            with Connection(server, user=user_dn, password=password, authentication=NTLM, auto_bind=True) as conn:
+                logger.debug("LDAP bind successful for %s", username)
+                return self._fetch_user_info(conn, username)
+        except Exception:  # noqa: BLE001
+            logger.info("LDAP bind failed for %s", username)
+            return None
+
+    def is_admin(self, user: UserInfo) -> bool:
+        username_lower = user.username.lower()
+        if username_lower in {u.lower() for u in self.settings.admin_users}:
+            return True
+        if not self.settings.admin_group_dn:
+            return False
+        try:
+            with _service_connection(self.settings) as conn:
+                conn.search(
+                    search_base=self.settings.admin_group_dn,
+                    search_filter="(objectClass=group)",
+                    search_scope=SUBTREE,
+                    attributes=["member"],
+                )
+                if not conn.entries:
+                    return False
+                members = conn.entries[0].member.values if hasattr(conn.entries[0], "member") else []
+                username_dn = self._build_user_dn(username_lower)
+                return any(member.lower() == username_dn.lower() for member in members)
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to check admin group membership", exc_info=True)
+            return username_lower in {u.lower() for u in self.settings.admin_users}
+
+    def _fetch_user_info(self, conn: Connection, username: str) -> Optional[UserInfo]:
+        search_filter = f"(sAMAccountName={username})"
+        conn.search(
+            search_base=self.settings.ldap_base_dn,
+            search_filter=search_filter,
+            attributes=[
+                "sAMAccountName",
+                self.settings.ldap_mail_attr,
+                self.settings.ldap_display_attr,
+            ],
+        )
+        if not conn.entries:
+            logger.warning("LDAP user %s not found after successful bind", username)
+            return None
+        entry = conn.entries[0]
+        email = getattr(entry, self.settings.ldap_mail_attr, None)
+        display_name = getattr(entry, self.settings.ldap_display_attr, None)
+        return UserInfo(
+            username=username,
+            email=(email.value if email else None),
+            display_name=(display_name.value if display_name else None),
+        )
+
+    def _build_user_dn(self, username: str) -> str:
+        return f"CN={username},{self.settings.ldap_base_dn}"
+
+    def _domain_from_bind(self) -> str:
+        if "@" in self.settings.ldap_bind_dn:
+            return self.settings.ldap_bind_dn.split("@", 1)[1]
+        parts = [p.split("=")[1] for p in self.settings.ldap_bind_dn.split(",") if p.strip().startswith("DC=")]
+        return ".".join(parts)

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import csv
+import io
+import logging
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple, Union
+
+from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
+from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+
+from .auth import (
+    authenticate_and_create_session,
+    get_current_user,
+    require_admin,
+    get_session_manager,
+)
+from .config import Settings, get_settings
+from .keys_store import KeyStore
+from .models import AppKeyRequest, AppKeyResponse, AuthenticatedUser, LoginRequest, PersonalKeyResponse
+from .scheduler import ExpiryScheduler
+
+logger = logging.getLogger(__name__)
+
+
+def create_app(settings: Settings | None = None) -> FastAPI:
+    settings = settings or get_settings()
+    configure_logging(settings)
+
+    app = FastAPI(title="vLLM Key Portal", version="1.0.0")
+
+    if settings.https_only:
+        app.add_middleware(HTTPSRedirectMiddleware)
+
+    static_dir = Path(__file__).parent.parent / "static"
+    static_dir.mkdir(parents=True, exist_ok=True)
+    app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
+
+    @app.get("/", include_in_schema=False)
+    async def index() -> RedirectResponse:
+        return RedirectResponse(url="/static/index.html")
+
+    key_store = KeyStore(settings)
+    scheduler = ExpiryScheduler(settings, key_store)
+
+    @app.on_event("startup")
+    async def startup_event() -> None:
+        scheduler.start()
+
+    @app.on_event("shutdown")
+    async def shutdown_event() -> None:
+        await scheduler.stop()
+
+    @app.middleware("http")
+    async def security_headers(request: Request, call_next):
+        response = await call_next(request)
+        response.headers.setdefault("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+        response.headers.setdefault("X-Content-Type-Options", "nosniff")
+        response.headers.setdefault("X-Frame-Options", "DENY")
+        response.headers.setdefault("Referrer-Policy", "no-referrer")
+        return response
+
+    def get_key_store_dep() -> KeyStore:
+        return key_store
+
+    def mask_key(value: str) -> str:
+        if len(value) <= 4:
+            return "****"
+        return "*" * (len(value) - 4) + value[-4:]
+
+    @app.post("/auth/login", response_model=AuthenticatedUser)
+    async def login(user: AuthenticatedUser = Depends(authenticate_and_create_session)) -> AuthenticatedUser:
+        return user
+
+    @app.post("/auth/logout")
+    async def logout(response: Response, session_manager=Depends(get_session_manager)) -> Dict[str, str]:
+        session_manager.clear(response)
+        return {"detail": "logged out"}
+
+    @app.get("/me", response_model=AuthenticatedUser)
+    async def get_me(user: AuthenticatedUser = Depends(get_current_user)) -> AuthenticatedUser:
+        return user
+
+    @app.get("/me/key", response_model=Union[PersonalKeyResponse, Dict[str, str]])
+    async def get_my_key(
+        user: AuthenticatedUser = Depends(get_current_user),
+        key_store: KeyStore = Depends(get_key_store_dep),
+    ) -> Union[PersonalKeyResponse, Dict[str, str]]:
+        result = key_store.get_personal_key(user.identifier)
+        if not result:
+            return {}
+        subject, entry = result
+        return PersonalKeyResponse(
+            subject=subject,
+            key=entry.key,
+            created_at=entry.created_at,
+            expires_at=entry.expires_at,
+        )
+
+    @app.post("/me/key:regenerate", response_model=PersonalKeyResponse)
+    async def regenerate_my_key(
+        request: Request,
+        user: AuthenticatedUser = Depends(get_current_user),
+        key_store: KeyStore = Depends(get_key_store_dep),
+        settings: Settings = Depends(get_settings),
+    ) -> PersonalKeyResponse:
+        entry = key_store.upsert_personal_key(
+            identifier=user.identifier,
+            ttl_days=settings.key_default_ttl_days,
+            actor=user.identifier,
+            ip=request.client.host if request.client else None,
+        )
+        return PersonalKeyResponse(
+            subject=f"user:{user.identifier}",
+            key=entry.key,
+            created_at=entry.created_at,
+            expires_at=entry.expires_at,
+        )
+
+    @app.delete("/me/key")
+    async def delete_my_key(
+        request: Request,
+        user: AuthenticatedUser = Depends(get_current_user),
+        key_store: KeyStore = Depends(get_key_store_dep),
+    ) -> Dict[str, str]:
+        key_store.delete_personal_key(
+            identifier=user.identifier,
+            actor=user.identifier,
+            ip=request.client.host if request.client else None,
+        )
+        return {"detail": "deleted"}
+
+    @app.get("/admin/keys")
+    async def list_keys(
+        skip: int = 0,
+        limit: int = 100,
+        subject_filter: str | None = None,
+        _: AuthenticatedUser = Depends(require_admin),
+        key_store: KeyStore = Depends(get_key_store_dep),
+    ) -> Dict[str, Iterable[Dict[str, str]]]:
+        entries = list(key_store.list_entries())
+        if subject_filter:
+            entries = [item for item in entries if subject_filter in item[0]]
+        total = len(entries)
+        sliced = entries[skip : skip + limit]
+        return {
+            "items": [
+                {
+                    "subject": subject,
+                    "key": mask_key(entry.key),
+                    "created_at": entry.created_at,
+                    "expires_at": entry.expires_at,
+                }
+                for subject, entry in sliced
+            ],
+            "total": total,
+        }
+
+    @app.post("/admin/app-keys", response_model=AppKeyResponse)
+    async def create_app_key(
+        request: Request,
+        payload: AppKeyRequest,
+        user: AuthenticatedUser = Depends(require_admin),
+        key_store: KeyStore = Depends(get_key_store_dep),
+    ) -> AppKeyResponse:
+        if key_store.has_app_key(payload.name):
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="App key already exists")
+        entry = key_store.set_app_key(
+            name=payload.name,
+            key=payload.key,
+            actor=user.identifier,
+            ip=request.client.host if request.client else None,
+        )
+        subject = f"app:{payload.name}"
+        return AppKeyResponse(name=subject, key=entry.key, created_at=entry.created_at, expires_at=entry.expires_at)
+
+    @app.put("/admin/app-keys/{name}", response_model=AppKeyResponse)
+    async def rotate_app_key(
+        name: str,
+        request: Request,
+        user: AuthenticatedUser = Depends(require_admin),
+        key_store: KeyStore = Depends(get_key_store_dep),
+    ) -> AppKeyResponse:
+        normalized = name.lower()
+        if not key_store.has_app_key(normalized):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="App key not found")
+        entry = key_store.set_app_key(
+            name=normalized,
+            key=None,
+            actor=user.identifier,
+            ip=request.client.host if request.client else None,
+        )
+        subject = f"app:{normalized}"
+        return AppKeyResponse(name=subject, key=entry.key, created_at=entry.created_at, expires_at=entry.expires_at)
+
+    @app.delete("/admin/app-keys/{name}")
+    async def delete_app_key(
+        name: str,
+        request: Request,
+        user: AuthenticatedUser = Depends(require_admin),
+        key_store: KeyStore = Depends(get_key_store_dep),
+    ) -> Dict[str, str]:
+        normalized = name.lower()
+        if not key_store.has_app_key(normalized):
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="App key not found")
+        key_store.delete_app_key(
+            name=normalized,
+            actor=user.identifier,
+            ip=request.client.host if request.client else None,
+        )
+        return {"detail": "deleted"}
+
+    @app.get("/admin/export.csv")
+    async def export_csv(
+        _: AuthenticatedUser = Depends(require_admin),
+        key_store: KeyStore = Depends(get_key_store_dep),
+    ) -> Response:
+        entries = key_store.list_entries()
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        writer.writerow(["subject", "key", "created_at", "expires_at"])
+        for subject, entry in entries:
+            writer.writerow([
+                subject,
+                mask_key(entry.key),
+                entry.created_at.isoformat(),
+                entry.expires_at.isoformat() if entry.expires_at else "",
+            ])
+        response = Response(content=buffer.getvalue(), media_type="text/csv")
+        response.headers["Content-Disposition"] = "attachment; filename=keys.csv"
+        return response
+
+    return app
+
+
+def configure_logging(settings: Settings) -> None:
+    log_path = settings.audit_log_path.parent / "application.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        handlers=[
+            logging.StreamHandler(),
+            logging.FileHandler(log_path, encoding="utf-8"),
+        ],
+    )
+
+
+app = create_app()

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Dict, Optional
+
+from pydantic import BaseModel, EmailStr, Field, validator
+
+
+class KeyEntry(BaseModel):
+    key: str
+    created_at: datetime
+    expires_at: Optional[datetime] = None
+
+    @validator("created_at", "expires_at", pre=True)
+    def _parse_datetime(cls, value):
+        if value is None:
+            return value
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                return value.replace(tzinfo=timezone.utc)
+            return value.astimezone(timezone.utc)
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(timezone.utc)
+
+    class Config:
+        json_encoders = {
+            datetime: lambda dt: dt.astimezone(timezone.utc).replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z")
+        }
+
+
+class KeysDocument(BaseModel):
+    gpt: Dict[str, KeyEntry] = Field(default_factory=dict)
+
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+class UserInfo(BaseModel):
+    username: str
+    email: Optional[EmailStr]
+    display_name: Optional[str]
+
+    @property
+    def identifier(self) -> str:
+        if self.email:
+            return self.email.lower()
+        if self.display_name:
+            return self.display_name
+        return self.username
+
+
+class AuthenticatedUser(BaseModel):
+    username: str
+    email: Optional[EmailStr]
+    display_name: Optional[str]
+    is_admin: bool
+
+    @property
+    def identifier(self) -> str:
+        if self.email:
+            return self.email.lower()
+        if self.display_name:
+            return self.display_name
+        return self.username
+
+
+class AppKeyRequest(BaseModel):
+    name: str = Field(..., regex=r"^[a-zA-Z0-9][a-zA-Z0-9_.-]{1,62}$")
+    key: Optional[str] = Field(default=None, min_length=8)
+
+    @validator("name")
+    def _lower(cls, value: str) -> str:
+        return value.lower()
+
+
+class AppKeyResponse(BaseModel):
+    name: str
+    key: str
+    created_at: datetime
+    expires_at: Optional[datetime]
+
+
+class PersonalKeyResponse(BaseModel):
+    subject: str
+    key: str
+    created_at: datetime
+    expires_at: datetime

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+
+from .config import Settings
+from .keys_store import KeyStore
+
+logger = logging.getLogger(__name__)
+
+
+class ExpiryScheduler:
+    def __init__(self, settings: Settings, key_store: KeyStore):
+        self.settings = settings
+        self.key_store = key_store
+        self._task: asyncio.Task | None = None
+        self._stop_event = asyncio.Event()
+
+    def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._stop_event.clear()
+            self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._stop_event.set()
+        if self._task:
+            await self._task
+
+    async def _run(self) -> None:
+        interval = timedelta(hours=1)
+        logger.info("Starting key expiration scheduler with interval %s", interval)
+        try:
+            while not self._stop_event.is_set():
+                removed = self.key_store.expire_stale_keys()
+                if removed:
+                    logger.info("Expired %s stale keys", removed)
+                try:
+                    await asyncio.wait_for(self._stop_event.wait(), timeout=interval.total_seconds())
+                except asyncio.TimeoutError:
+                    continue
+        except Exception:  # noqa: BLE001
+            logger.exception("Key expiration scheduler failed")
+        finally:
+            logger.info("Key expiration scheduler stopped")

--- a/deploy/vllm-keyportal.service
+++ b/deploy/vllm-keyportal.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=vLLM Key Portal
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/vllm-keyportal.env
+WorkingDirectory=/opt/vllm-keyportal
+ExecStart=/usr/bin/env uvicorn app.main:app --host 0.0.0.0 --port 8443
+Restart=on-failure
+User=vllm
+Group=vllm
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.29.0
+ldap3>=2.9
+itsdangerous>=2.1
+pydantic>=1.10
+python-multipart>=0.0.9
+httpx>=0.27
+pytest>=7.4
+pytest-asyncio>=0.21

--- a/settings.example.toml
+++ b/settings.example.toml
@@ -1,0 +1,13 @@
+LDAP_URI = "ldaps://ad.example.com"
+LDAP_BIND_DN = "CN=svc,OU=Service Accounts,DC=example,DC=com"
+LDAP_BIND_PASSWORD = "change-me"
+LDAP_BASE_DN = "DC=example,DC=com"
+LDAP_MAIL_ATTR = "mail"
+LDAP_DISPLAY_ATTR = "displayName"
+ADMIN_USERS = ["uri.tzabari", "alex.grishankov"]
+# ADMIN_GROUP_DN = "CN=Platform Admins,OU=Groups,DC=example,DC=com"
+KEYS_JSON_PATH = "/etc/vllm/keys.json"
+KEY_DEFAULT_TTL_DAYS = 30
+SESSION_SECRET = "replace-with-random-secret"
+HTTPS_ONLY = true
+AUDIT_LOG_PATH = "/var/log/vllm-keyportal/audit.log"

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>vLLM Key Portal</title>
+  <link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+  <main>
+    <section id="auth-section">
+      <h1>vLLM Key Portal</h1>
+      <form id="login-form">
+        <h2>Login</h2>
+        <label>Username<input type="text" name="username" required /></label>
+        <label>Password<input type="password" name="password" required /></label>
+        <button type="submit">Login</button>
+        <p class="error" id="login-error"></p>
+      </form>
+      <button id="logout-btn" hidden>Logout</button>
+      <div id="user-info" hidden></div>
+    </section>
+
+    <section id="user-key-section" hidden>
+      <h2>My Personal Key</h2>
+      <pre id="my-key-display">No key</pre>
+      <button id="generate-key">Generate / Rotate</button>
+      <button id="delete-key">Delete</button>
+    </section>
+
+    <section id="admin-section" hidden>
+      <h2>Application Keys</h2>
+      <form id="create-app-form">
+        <label>App name<input type="text" name="name" required /></label>
+        <label>Custom key (optional)<input type="text" name="key" /></label>
+        <button type="submit">Create</button>
+        <p class="error" id="create-app-error"></p>
+      </form>
+      <table id="app-keys-table">
+        <thead>
+          <tr><th>Subject</th><th>Key</th><th>Created</th><th>Expires</th><th>Actions</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+  </main>
+  <script src="/static/main.js"></script>
+</body>
+</html>

--- a/static/main.js
+++ b/static/main.js
@@ -1,0 +1,183 @@
+async function api(path, options = {}) {
+  const response = await fetch(path, {
+    ...options,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(options.headers || {}),
+    },
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    let detail = 'Request failed';
+    try {
+      const data = await response.json();
+      detail = data.detail || JSON.stringify(data);
+    } catch (err) {
+      detail = response.statusText;
+    }
+    throw new Error(detail);
+  }
+  if (response.headers.get('content-type')?.includes('application/json')) {
+    return response.json();
+  }
+  return response.text();
+}
+
+const loginForm = document.getElementById('login-form');
+const logoutBtn = document.getElementById('logout-btn');
+const loginError = document.getElementById('login-error');
+const userInfo = document.getElementById('user-info');
+const userKeySection = document.getElementById('user-key-section');
+const adminSection = document.getElementById('admin-section');
+const myKeyDisplay = document.getElementById('my-key-display');
+const generateKeyBtn = document.getElementById('generate-key');
+const deleteKeyBtn = document.getElementById('delete-key');
+const createAppForm = document.getElementById('create-app-form');
+const createAppError = document.getElementById('create-app-error');
+const appKeysTableBody = document.querySelector('#app-keys-table tbody');
+
+async function refreshUser() {
+  try {
+    const me = await api('/me');
+    loginForm.hidden = true;
+    logoutBtn.hidden = false;
+    userInfo.hidden = false;
+    userInfo.textContent = `${me.username} (${me.email || 'no email'}) - ${me.is_admin ? 'admin' : 'user'}`;
+    userKeySection.hidden = false;
+    loginError.textContent = '';
+    await refreshMyKey();
+    if (me.is_admin) {
+      adminSection.hidden = false;
+      await refreshAppKeys();
+    } else {
+      adminSection.hidden = true;
+    }
+  } catch (err) {
+    loginForm.hidden = false;
+    logoutBtn.hidden = true;
+    userInfo.hidden = true;
+    userKeySection.hidden = true;
+    adminSection.hidden = true;
+  }
+}
+
+async function refreshMyKey() {
+  try {
+    const data = await api('/me/key');
+    if (!data.subject) {
+      myKeyDisplay.textContent = 'No key';
+    } else {
+      myKeyDisplay.textContent = JSON.stringify(data, null, 2);
+    }
+  } catch (err) {
+    myKeyDisplay.textContent = err.message;
+  }
+}
+
+async function refreshAppKeys() {
+  try {
+    const data = await api('/admin/keys');
+    appKeysTableBody.innerHTML = '';
+    data.items.forEach(item => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${item.subject}</td>
+        <td>${item.key}</td>
+        <td>${item.created_at}</td>
+        <td>${item.expires_at ?? ''}</td>
+        <td>
+          <button data-action="rotate" data-name="${item.subject.replace('app:', '')}">Rotate</button>
+          <button data-action="delete" data-name="${item.subject.replace('app:', '')}">Delete</button>
+        </td>
+      `;
+      appKeysTableBody.appendChild(row);
+    });
+  } catch (err) {
+    createAppError.textContent = err.message;
+  }
+}
+
+loginForm?.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const formData = new FormData(loginForm);
+  try {
+    await api('/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({
+        username: formData.get('username'),
+        password: formData.get('password'),
+      }),
+    });
+    loginError.textContent = '';
+    await refreshUser();
+  } catch (err) {
+    loginError.textContent = err.message;
+  }
+});
+
+logoutBtn?.addEventListener('click', async () => {
+  await api('/auth/logout', { method: 'POST' });
+  loginForm.hidden = false;
+  logoutBtn.hidden = true;
+  userInfo.hidden = true;
+  userKeySection.hidden = true;
+  adminSection.hidden = true;
+});
+
+generateKeyBtn?.addEventListener('click', async () => {
+  try {
+    const data = await api('/me/key:regenerate', { method: 'POST' });
+    myKeyDisplay.textContent = JSON.stringify(data, null, 2);
+  } catch (err) {
+    myKeyDisplay.textContent = err.message;
+  }
+});
+
+deleteKeyBtn?.addEventListener('click', async () => {
+  try {
+    await api('/me/key', { method: 'DELETE' });
+    myKeyDisplay.textContent = 'No key';
+  } catch (err) {
+    myKeyDisplay.textContent = err.message;
+  }
+});
+
+createAppForm?.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const formData = new FormData(createAppForm);
+  try {
+    await api('/admin/app-keys', {
+      method: 'POST',
+      body: JSON.stringify({
+        name: formData.get('name'),
+        key: formData.get('key') || undefined,
+      }),
+    });
+    createAppForm.reset();
+    createAppError.textContent = '';
+    await refreshAppKeys();
+  } catch (err) {
+    createAppError.textContent = err.message;
+  }
+});
+
+appKeysTableBody?.addEventListener('click', async (event) => {
+  const target = event.target;
+  if (!(target instanceof HTMLButtonElement)) {
+    return;
+  }
+  const name = target.dataset.name;
+  const action = target.dataset.action;
+  try {
+    if (action === 'rotate') {
+      await api(`/admin/app-keys/${name}`, { method: 'PUT' });
+    } else if (action === 'delete') {
+      await api(`/admin/app-keys/${name}`, { method: 'DELETE' });
+    }
+    await refreshAppKeys();
+  } catch (err) {
+    createAppError.textContent = err.message;
+  }
+});
+
+refreshUser();

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,70 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #f5f5f5;
+  margin: 0;
+  padding: 0;
+}
+
+main {
+  max-width: 960px;
+  margin: 2rem auto;
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border: none;
+  background: #2563eb;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+button[hidden] {
+  display: none;
+}
+
+pre {
+  background: #111827;
+  color: #f9fafb;
+  padding: 1rem;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.error {
+  color: #dc2626;
+  min-height: 1em;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+td, th {
+  border: 1px solid #e5e7eb;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+th {
+  background: #f3f4f6;
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.config import Settings, get_settings
+from app.main import create_app
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def settings(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Settings:
+    keys_path = tmp_path / "keys.json"
+    audit_log = tmp_path / "audit.log"
+    env = {
+        "LDAP_URI": "ldap://test",
+        "LDAP_BIND_DN": "CN=svc,DC=example,DC=com",
+        "LDAP_BIND_PASSWORD": "secret",
+        "LDAP_BASE_DN": "DC=example,DC=com",
+        "LDAP_MAIL_ATTR": "mail",
+        "LDAP_DISPLAY_ATTR": "displayName",
+        "ADMIN_USERS": "admin",
+        "KEYS_JSON_PATH": str(keys_path),
+        "KEY_DEFAULT_TTL_DAYS": "30",
+        "SESSION_SECRET": "test-secret",
+        "HTTPS_ONLY": "false",
+        "AUDIT_LOG_PATH": str(audit_log),
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    settings = Settings()
+    return settings
+
+
+@pytest.fixture
+def app_client(settings: Settings, monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    app = create_app(settings)
+    with TestClient(app) as client:
+        yield client

--- a/tests/test_admin_logic.py
+++ b/tests/test_admin_logic.py
@@ -1,0 +1,58 @@
+from contextlib import contextmanager
+
+import pytest
+
+from app.config import Settings
+from app.ldap_client import LDAPClient
+from app.models import UserInfo
+
+
+def test_admin_users_only(settings: Settings):
+    client = LDAPClient(settings)
+    user = UserInfo(username="admin", email="admin@example.com", display_name="Admin")
+    assert client.is_admin(user) is True
+
+    non_admin = UserInfo(username="bob", email="bob@example.com", display_name="Bob")
+    assert client.is_admin(non_admin) is False
+
+
+def test_admin_group_lookup(monkeypatch: pytest.MonkeyPatch, settings: Settings):
+    settings.admin_group_dn = "CN=Admins,DC=example,DC=com"
+    client = LDAPClient(settings)
+
+    class FakeEntry:
+        class Member:
+            values = ["CN=bob,DC=example,DC=com"]
+
+        member = Member()
+
+    class FakeConnection:
+        entries = [FakeEntry()]
+
+        def search(self, *args, **kwargs):
+            return True
+
+    @contextmanager
+    def fake_service_connection(settings):
+        yield FakeConnection()
+
+    monkeypatch.setattr("app.ldap_client._service_connection", fake_service_connection)
+
+    user = UserInfo(username="bob", email="bob@example.com", display_name="Bob")
+    assert client.is_admin(user) is True
+
+
+def test_admin_group_lookup_failure(monkeypatch: pytest.MonkeyPatch, settings: Settings):
+    settings.admin_group_dn = "CN=Admins,DC=example,DC=com"
+    client = LDAPClient(settings)
+
+    @contextmanager
+    def fake_service_connection(settings):
+        raise RuntimeError("LDAP down")
+        yield
+
+    monkeypatch.setattr("app.ldap_client._service_connection", fake_service_connection)
+
+    user = UserInfo(username="alice", email="alice@example.com", display_name="Alice")
+    # Falls back to admin_users list which contains only "admin"
+    assert client.is_admin(user) is False

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,34 @@
+import pytest
+
+from app import auth
+from app.models import UserInfo
+
+
+@pytest.fixture(autouse=True)
+def mock_ldap(monkeypatch: pytest.MonkeyPatch):
+    def fake_auth(self, username: str, password: str) -> UserInfo | None:
+        if username == "alice" and password == "pass":
+            return UserInfo(username=username, email="alice@example.com", display_name="Alice")
+        return None
+
+    def fake_is_admin(self, user: UserInfo) -> bool:
+        return user.username == "admin"
+
+    monkeypatch.setattr(auth.LDAPClient, "authenticate", fake_auth, raising=False)
+    monkeypatch.setattr(auth.LDAPClient, "is_admin", fake_is_admin, raising=False)
+    yield
+
+
+def test_login_success(app_client):
+    response = app_client.post("/auth/login", json={"username": "alice", "password": "pass"})
+    assert response.status_code == 200
+    body = response.json()
+    assert body["username"] == "alice"
+    assert body["is_admin"] is False
+    assert "vllm_session" in response.cookies
+
+
+def test_login_failure(app_client):
+    response = app_client.post("/auth/login", json={"username": "alice", "password": "wrong"})
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid credentials"

--- a/tests/test_key_store.py
+++ b/tests/test_key_store.py
@@ -1,0 +1,43 @@
+import threading
+from datetime import datetime, timedelta, timezone
+
+from app.keys_store import KeyStore
+from app.models import KeyEntry, KeysDocument
+
+
+def test_concurrent_updates(settings):
+    store = KeyStore(settings)
+    errors = []
+
+    def worker(user_id: str):
+        try:
+            store.upsert_personal_key(identifier=user_id, ttl_days=30, actor=user_id, ip=None)
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(f"user{i}@example.com",)) for i in range(10)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors
+    entries = dict(store.list_entries())
+    assert len(entries) == 10
+
+
+def test_expire_stale_keys(settings, tmp_path):
+    store = KeyStore(settings)
+    now = datetime.now(timezone.utc)
+    document = KeysDocument(
+        gpt={
+            "user:old@example.com": KeyEntry(key="old", created_at=now - timedelta(days=31), expires_at=now - timedelta(days=1)),
+            "user:current@example.com": KeyEntry(key="cur", created_at=now, expires_at=now + timedelta(days=10)),
+        }
+    )
+    store._write_document(document)
+    removed = store.expire_stale_keys()
+    assert removed == 1
+    remaining = dict(store.list_entries())
+    assert "user:old@example.com" not in remaining
+    assert "user:current@example.com" in remaining

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,14 @@
+from app import auth
+from app.models import UserInfo
+
+
+def test_security_headers(app_client, monkeypatch):
+    # ensure login to avoid redirect loops
+    monkeypatch.setattr(auth.LDAPClient, "authenticate", lambda self, u, p: UserInfo(username="alice", email="a@b", display_name="A"), raising=False)
+    monkeypatch.setattr(auth.LDAPClient, "is_admin", lambda self, user: False, raising=False)
+    app_client.post("/auth/login", json={"username": "alice", "password": "pass"})
+    response = app_client.get("/")
+    assert response.headers["Strict-Transport-Security"].startswith("max-age=")
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+    assert response.headers["X-Frame-Options"] == "DENY"
+    assert response.headers["Referrer-Policy"] == "no-referrer"

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,32 @@
+import pytest
+
+from app import auth
+from app.models import UserInfo
+
+
+@pytest.fixture
+def admin_client(app_client, monkeypatch: pytest.MonkeyPatch):
+    def fake_auth(self, username: str, password: str):
+        return UserInfo(username="admin", email="admin@example.com", display_name="Admin")
+
+    def fake_is_admin(self, user: UserInfo) -> bool:
+        return True
+
+    monkeypatch.setattr(auth.LDAPClient, "authenticate", fake_auth, raising=False)
+    monkeypatch.setattr(auth.LDAPClient, "is_admin", fake_is_admin, raising=False)
+    response = app_client.post("/auth/login", json={"username": "admin", "password": "pass"})
+    assert response.status_code == 200
+    return app_client
+
+
+def test_invalid_app_name(admin_client):
+    response = admin_client.post("/admin/app-keys", json={"name": "!bad", "key": "abcd1234"})
+    assert response.status_code == 422
+
+
+def test_duplicate_app_name(admin_client):
+    first = admin_client.post("/admin/app-keys", json={"name": "doc", "key": "abcd1234"})
+    assert first.status_code == 200
+    dup = admin_client.post("/admin/app-keys", json={"name": "doc", "key": "abcd1234"})
+    assert dup.status_code == 409
+    assert dup.json()["detail"] == "App key already exists"


### PR DESCRIPTION
## Summary
- replace the legacy PHP artifacts with a FastAPI application that exposes LDAP-authenticated personal and application key management endpoints and a minimal static UI
- persist keys in a JSON file with advisory locking, audit logging, and scheduled expiry pruning
- add deployment collateral including configuration samples, systemd unit, and unit tests for auth flows, admin detection, locking, and input validation

## Testing
- `pytest` *(fails: missing fastapi dependency in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2374b52fc83218b03f9ce26707d65